### PR TITLE
Change lognroll name in events

### DIFF
--- a/content/analytics-events-catalogue/analytics-events-catalogue.md
+++ b/content/analytics-events-catalogue/analytics-events-catalogue.md
@@ -21,6 +21,6 @@ This document links to the analytics documentation for Applicaster's consumer pr
 
 [GroupChat - Analytics Events](http://developer.applicaster.com/docs/public/group-chat-analytics)
 
-#### logNroll
+#### Questionnaire
 
-[logNroll - Analytics Events](http://developer.applicaster.com/docs/internal/lognroll-analytics)
+[Questionnaire - Analytics Events](http://developer.applicaster.com/docs/internal/questionnaire-analytics)


### PR DESCRIPTION
It’s now called questionnaire. Update in events hub
