### PR TITLE
Added support documentation for YouTube video to Applicaster Media Atom Feed

### DIFF
--- a/content/media-atom/applicaster-media-atom-feed.md
+++ b/content/media-atom/applicaster-media-atom-feed.md
@@ -9,12 +9,13 @@
 | 1.3.0 | Support of video resource type. |
 | 1.4.0 | Articles support audio mediaGroup. |
 | 1.5.0 | ATOM with advertisement tags. |
+| 1.6.0 | Support of YouTube video resource type. |
 
 
 
 # Overview
 Applicaster *Media Atom Feed* is a feature that
-allows the broadcaster to integrate list 
+allows the broadcaster to integrate list
 
 | Version | Description |
 | - | - |
@@ -25,7 +26,7 @@ allows the broadcaster to integrate list
 | 1.3.0 | Support of video resource type. |
 | 1.4.0 | Articles support audio mediaGroup. |
 | 1.5.0 | ATOM with advertisement tags. |
-
+| 1.6.0 | Support of YouTube video resource type. |
 
 
 # Overview
@@ -33,8 +34,8 @@ Applicaster *Media Atom Feed* is a feature that
 allows the broadcaster to integrate list of
 External resources and present them in the app.
 Currently Applicaster supports the following
-resource types: **Article**, **Gallery**
-and **Video**. The broadcaster should host the
+resource types: **Article**, **Gallery**, **Video**
+and **YouTube Video**. The broadcaster should host the
 resources in its own servers and provide
 Applicaster with the links to the Atom feeds
 according to the specifications
@@ -45,6 +46,7 @@ below.
 * Gallery - Upon tapping, the gallery will be presented in the following layout:
 ![image](./images/photoGallery4.png)
 * Video - HLS video content, upon tapping the content will be presented on a video player.
+* YouTube Video - YouTube video content, upon tapping the content will be presented using a YouTube player.
 
 ### Setup
 
@@ -94,7 +96,8 @@ Conditional GET using `If-Modified-Since`,
 [Link](https://github.com/applicaster/developer.applicaster.com/blob/developer2/content/media-atom/examples/article%2Bvideo%2Baudio.xml)
 * Feed that holds image gallery entries.
 [Link](https://github.com/applicaster/developer.applicaster.com/blob/developer2/content/media-atom/examples/galleries.xml)
-
+* Feed that holds a YouTube video.
+[Link](https://github.com/applicaster/developer.applicaster.com/blob/developer2/content/media-atom/examples/youtube.xml)
 
 ## Elements and Attributes Description
 Described below are all the custom extensions
@@ -129,7 +132,7 @@ to one of the following:
 * For Article use: `<applicaster:type
 value="article"/>`
 
-* For Video use: `<applicaster:type
+* For Video (HLS or YouTube) use: `<applicaster:type
 value="video"/>`
 
 * For Image-Gallery: `<applicaster:type
@@ -183,7 +186,7 @@ This tag may include two tags:
 `<interstitial ios_iphone_adUnit = "" ios_ipad_adUnit = "" android_smartPhone_adUnit = "" android_tablet_adUnit = ""/>`  
 This tag should represent where interstitial content comes from.  
 When this tag is added it MUST includes properties any device types.
-* ### banner 
+* ### banner
 `<banner ios_iphone_adUnit = "" ios_ipad_adUnit = "" android_smartPhone_adUnit = "" android_tablet_adUnit = ""/>`  
 This tag should represent where banner content comes from.  
 When this tag is added it MUST includes properties any device types.
@@ -205,6 +208,7 @@ depends on the Entry type:
 <kbd>image/png</kbd>, <kbd>image/gif</kbd>,
 <kbd>image/jpg</kbd>, <kbd>image/jpeg</kbd>
 * For Video use <kbd>video/hls</kbd>
+* for YouTube Video use <kbd>youtube-id</kbd>
 * For Image-gallery use
 <kbd>application/atom+xml</kbd>
 
@@ -229,6 +233,8 @@ value="image"/>`. Entries without
 the `<applicaster:type
 value="image"/>` element will be discarded.
 
+* YouTube Video type MUST have a `src` attribute
+with the YouTube video ID.
 
 ### applicaster media group
 `<applicaster:mediaGroup>` <span
@@ -303,8 +309,8 @@ All options are described here:
 
 External resources and present them in the app.
 Currently Applicaster supports the following
-resource types: **Article**, **Gallery**
-and **Video**. The broadcaster should host the
+resource types: **Article**, **Gallery**, **Video**
+and **YouTube Video**. The broadcaster should host the
 resources in its own servers and provide
 Applicaster with the links to the Atom feeds
 according to the specifications
@@ -315,6 +321,7 @@ below.
 * Gallery - Upon tapping, the gallery will be presented in the following layout:
 ![image](./images/photoGallery4.png)
 * Video - HLS video content, upon tapping the content will be presented on a video player.
+* YouTube Video - YouTube video content, upon tapping the content will be presented using a YouTube player.
 
 ### Setup
 
@@ -364,6 +371,8 @@ Conditional GET using `If-Modified-Since`,
 [Link](https://github.com/applicaster/developer.applicaster.com/blob/developer2/content/media-atom/examples/article%2Bvideo%2Baudio.xml)
 * Feed that holds image gallery entries.
 [Link](https://github.com/applicaster/developer.applicaster.com/blob/developer2/content/media-atom/examples/galleries.xml)
+* Feed that holds a YouTube video.
+[Link](https://github.com/applicaster/developer.applicaster.com/blob/developer2/content/media-atom/examples/youtube.xml)
 
 
 ## Elements and Attributes Description
@@ -399,7 +408,7 @@ to one of the following:
 * For Article use: `<applicaster:type
 value="article"/>`
 
-* For Video use: `<applicaster:type
+* For Video (HLS or YouTube) use: `<applicaster:type
 value="video"/>`
 
 * For Image-Gallery: `<applicaster:type
@@ -453,7 +462,7 @@ This tag may include two tags:
 `<interstitial ios_iphone_adUnit = "" ios_ipad_adUnit = "" android_smartPhone_adUnit = "" android_tablet_adUnit = ""/>`  
 This tag should represent where interstitial content comes from.  
 When this tag is added it MUST includes properties any device types.
-* ### banner 
+* ### banner
 `<banner ios_iphone_adUnit = "" ios_ipad_adUnit = "" android_smartPhone_adUnit = "" android_tablet_adUnit = ""/>`  
 This tag should represent where banner content comes from.  
 When this tag is added it MUST includes properties any device types.
@@ -475,6 +484,7 @@ depends on the Entry type:
 <kbd>image/png</kbd>, <kbd>image/gif</kbd>,
 <kbd>image/jpg</kbd>, <kbd>image/jpeg</kbd>
 * For Video use <kbd>video/hls</kbd>
+* for YouTube Video use <kbd>youtube-id</kbd>
 * For Image-gallery use
 <kbd>application/atom+xml</kbd>
 
@@ -499,6 +509,8 @@ value="image"/>`. Entries without
 the `<applicaster:type
 value="image"/>` element will be discarded.
 
+* YouTube Video type MUST have a `src` attribute
+with the YouTube video ID.
 
 ### applicaster media group
 `<applicaster:mediaGroup>` <span
@@ -560,7 +572,7 @@ This tag may include two tags:
 `<interstitial ios_iphone_adUnit = "" ios_ipad_adUnit = "" android_smartPhone_adUnit = "" android_tablet_adUnit = ""/>`  
 This tag should represent where interstitial content comes from.  
 When this tag is added it MUST includes properties any device types.
-* ### banner 
+* ### banner
 `<banner ios_iphone_adUnit = "" ios_ipad_adUnit = "" android_smartPhone_adUnit = "" android_tablet_adUnit = ""/>`  
 This tag should represent where banner content comes from.  
 When this tag is added it MUST includes properties any device types.

--- a/content/media-atom/examples/youtube.xml
+++ b/content/media-atom/examples/youtube.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+    xmlns:applicaster="http://schemas.applicaster.com/atom/1"
+    xml:lang="en-us">
+    <title>YouTube Feed Title</title>
+    <subtitle>YouTube Feed Subtitle</subtitle>
+    <link rel="self" type="application/atom+xml"
+    href="http://www.example.com/news_feed.atom"/>
+    <updated>2006-04-06T13:00:00-08:00</updated>
+    <id>http://www.example.com/article_feed.atom</id>
+    <author><name>Some Name</name></author>
+    <advertisement>
+        <interstitial ios_iphone_adUnit="aaaaa" ios_ipad_adUnit= "bbbb" android_smartPhone_adUnit="cccc" android_tablet_adUnit="dddd"/>
+        <banner ios_iphone_adUnit = "eee" ios_ipad_adUnit = "fff" android_smartPhone_adUnit = "ggg" android_tablet_adUnit = "hhh"/>
+    </advertisement>
+    <!-- -
+     Video example
+     <!- -->
+    <entry>
+        <applicaster:type value="video"/>
+        <title>Example YouTube Video Title #1</title>
+        <summary>Example Summery</summary>
+        <id>http://www.example.com/video1</id>
+        <published>2005-04-06T13:00:00-08:00</published>
+        <updated>2005-04-06T20:25:05-08:00</updated>
+        <content type="youtube-id"
+        src="2vjPBrBU-TM"/>
+        <applicaster:mediaGroup type="thumbnail">
+            <applicaster:mediaItem src="http://example.org/image-large.png" scale="large"/>
+            <applicaster:mediaItem src="http://example.org/image-small.png" scale="small"/>
+        </applicaster:mediaGroup>
+    </entry>
+</feed>

--- a/content/toc.yml
+++ b/content/toc.yml
@@ -353,9 +353,9 @@
     Applicaster Media Atom Feed is a feature that
     allows the broadcaster to integrate list of
     External resources and present them in the app.
-    Currently Applicaster supports three kinds of
-    resource types: article, image and
-    imageGallery.
+    Currently Applicaster supports five kinds of
+    resource types: article, image, imageGallery
+    and video (for both HLS and YouTube videos).
   type: Technical
   owner: p.kramarov@applicaster.com
 
@@ -415,7 +415,7 @@
   owner: y.osteen@applicaster.com
 
 "Measurement & Analytics":
-  
+
 - folder: analytics-plugins
   internal: true
   owner: e.bendavid@applicaster.com


### PR DESCRIPTION
This PR contains 3 parts:
1. Update the TOC to properly represent Video and YouTube video options
2. Update The Media Atom Feed documentation to contain YouTube video specifications
3. Add example XML containing a YouTube Video.

The only thing I'm considering adding is a note that says that YouTube support requires a new build and adding the YouTube plugin.
I didn't add that yet as I'm considering adding it as a default plugin.

If I tagged the wrong / missing people for this approval - would appreciate if someone can add it.

This will be merged AFTER the plugins are approved and published (Currently in review)
@drorg FYI
