### PR TITLE
Allows ingesting attributes for external purchases identification and…

### DIFF
--- a/content/vod-ingestion-xml/vod_via_xml.md
+++ b/content/vod-ingestion-xml/vod_via_xml.md
@@ -93,8 +93,7 @@ These are the same for all resource types:
 | `show_navigation`     | Should the application show back/forward buttons. Either `true` or `false`. default: `true`                                                                                                                                                                                      | No                                       |  link          |
 | `show_close_button`   | Should the application show a close button. Either `true` or `false`. default: `true`                                                                                                                                                                                            | No                                       |  link          |
 | `enable_zoom`         | Can the user change scale of the webview. Either `true` or `false`. default: `false`                                                                                                                                                                                             | No                                       | link          |
-| `external_free`       | Should the current item be marked as free based on a non applicaster system decision. Either `true` or `false`. default: `false`                                                                                                                               | No                                         | video      |
-| `external_product_ids` | Comma separated values that identify product identifiers related to the ingested VOD item in a non applicaster system. default: empty                                                                                                                          | No                                        | video      |
+| `external_policy`     | Includes a nested XML that contains values that are relevant for any client that needs to process this attribute                                                                                                                      | No                                         | video      |
 &#8224; *Only use this tag if you are sure the provided URLs are HLS streams that comply to Apple’s AppStore submission guidelines. using non compliant streams can result in the app being rejected by Apple.*
 ## The `<alternative_streams>` tag
 
@@ -305,8 +304,10 @@ This XML contains 2 videos that will be encoded and served by Applicaster.
           <url>http://example.com/path/to/episode1/large_thumbnail.jpg</url>
         </image_asset>
       </image_assets>
-      <external_free>false</external_free>
-      <external_product_ids>identifier1,identifier2,indentifier3</external_product_ids>
+      <external_policy>
+        <free>true</free>
+        <product_identifiers></product_identifiers>
+      </external_policy>
     </attributes>
   </resource>
   <resource>
@@ -327,7 +328,13 @@ This XML contains 2 videos that will be encoded and served by Applicaster.
           <url>http://example.com/path/to/episode2/large_thumbnail.jpg</url>
         </image_asset>
       </image_assets>
-      <external_product_ids></external_product_ids>
+      <external_policy>
+        <free>true</free>
+        <product_identifiers>
+          <id>1</id>
+          <id>34</id>
+        </product_identifiers>
+      </external_policy>
     </attributes>
   </resource>
 </resources>


### PR DESCRIPTION
@gavriguy 

We want to allow broadcaster to ingest some extra data when ingesting their VODs. Sometimes, content purchases management is not related to google play or applestore - in these cases we want to get a product identifier(s) so we can eventually return it in the API and in this way allow the mobile developers to mark properly an item on the screen. Usually I'd use the external id to macth items but the third parties that our customers hire are not the coolest/are not flexible for development