### PR TITLE
Rename the title of analytics integration documentation

### DIFF
--- a/content/toc.yml
+++ b/content/toc.yml
@@ -423,10 +423,11 @@
   description: >
     This doc describes how to integrate an analytics provider plugin on Android
   type: Technical
+  
 - folder: analytics-plugins-ios
   internal: false
   owner: e.bendavid@applicaster.com
-  title: "Analytics provider plugin on Android"
+  title: "Analytics provider plugin on iOS"
   description: >
     This doc describes how to integrate an analytics provider plugin on Android
   type: Technical


### PR DESCRIPTION
Stated Android, but supposed to be for iOS