### PR TITLE
fix: Fix textual mistakes in legacy docs intro and iOS dev env documents

### DIFF
--- a/book/applicaster-video-platform/intro.md
+++ b/book/applicaster-video-platform/intro.md
@@ -2,8 +2,8 @@
 
 The following documents contain information about integrating with the Applicaster Video Content Platform.
 
-The [Applicaster Video Content Platform](https://admin.applicaster.com) is used to serve content in some apps and enforce Authorization providers.
-Please note that the preffered way to include content in the app is currently using [Datasource providers](/Zapp-Pipes/Home.md) and content enforcement should use Login Plugins.
+The [Applicaster Video Content Platform](https://admin.applicaster.com) is used to serve content in apps which use it as a content management system, and to enforce enforce Authorization providers.
+Please note that the recommended way to deliver content in the app is currently using [Datasource providers](/Zapp-Pipes/Home.md) and content enforcement should use Login Plugins.
 
 ## Applicaster Content Ingestion
 * [VOD Ingestion VIA XML](/applicaster-video-platform/content-ingestion/vod-ingestion-xml/vod_via_xml.md)
@@ -13,12 +13,12 @@ Please note that the preffered way to include content in the app is currently us
 * [Collection Ingestion](/applicaster-video-platform/content-ingestion/collection-ingestion-xml/collection_via_xml.md)
 
 ## Authorization providers
-Authorization providers can be configured in the Applicaster Video Platform CMS in order to enforce video playback through JWT token granting by a third party service.
+Authorization providers can be configured in the Applicaster Video Platform CMS in order to enforce video playback through JWT tokens granting by a third party service.
 
-For more info about Authorization providers [Click Here](/applicaster-video-platform/authorization-provider/authorization_provider.md).
+For more info about Authorization providers, [Click Here](/applicaster-video-platform/authorization-provider/authorization_provider.md).
 
 ## JS2Native
 
-JS2Native is a basic layer of communication all Applicaster Webviews and RN instances implement to bridge some basic functionality between web / RN and native.
+JS2Native is a basic layer of communication all Applicaster Webviews and RN instances implement in order to bridge some basic functionality between web / RN and native.
 
-For more info about JS2Native [Click Here](/applicaster-video-platform/js2native/readme.md).
+For more info about JS2Native, [Click Here](/applicaster-video-platform/js2native/readme.md).

--- a/book/dev-env/iOS.md
+++ b/book/dev-env/iOS.md
@@ -28,7 +28,7 @@ Each plugin is comprised from a git repository including the following:
 * [Zapp Plugins Manifest](/zappifest/plugins-manifest-format.md)
 
 ### Example Podfile
-Here is an example of a basic podfile to include the dependancies and configurations used by our plugins:
+Here is an example of a basic podfile to include the dependencies and configurations used by our plugins:
 
 ```
 platform :ios, '10.0'
@@ -57,7 +57,7 @@ post_install do |installer|
 end
 ```
 
-This Podfile refrences the podspec and will create a structure where the plugin code is imported like a real project as a development pod.
+This Podfile references the podspec and will create a structure where the plugin code is imported like a real project as a development pod.
 
 ### Podspec example
 Here is a simple example for a podspec for a sample plugin:
@@ -100,12 +100,12 @@ end
 ```
 
 This podspec will also generate a bundle for the dynamic framework.
-If this is not needed - feel free to remove the resources section.
+If this is not needed, feel free to remove the resources section.
 
 Please refer to [Cocoapod's Guides](https://guides.cocoapods.org) for more info about advanced uses of cocoapods.
-This pod spec can be either hosted on one of Applicaster's repository, official Cocoapods specs repository or any other open git repository.
+This pod spec can be either hosted on one of Applicaster's repositories, official Cocoapods specs repository or any other open git repository.
 
-Note: While possible to host the podspecs specs directory inside the code library - please try to avoid this.
+Note: While possible to host the podspecs specs directory inside the code library, please try to avoid this.
 This method is not efficient.
 
 ## Starting a new project


### PR DESCRIPTION
This PR was approved on the old repository - hence will be merged and deployed