### PR TITLE
feat: add clarification that private repos must use ssh

### DIFF
--- a/book/dev-env/iOS.md
+++ b/book/dev-env/iOS.md
@@ -93,6 +93,8 @@ If this is not needed, feel free to remove the resources section.
 
 Please refer to our [Guide for deploying a plugin to cocoapods](/getting-started/ios-podspec.md) for instructions regarding the different options of hosting and serving the different podspec files and correctly versioning them.
 
+_NOTE: When using private pods and pod repositories - it is mandatory to use SSH - `git@github.com/<account>/<dependancy>.git` in the `s.source` field, and invite the CI github user to have access to the code. Unfortunatly HTTPS is not properly supported for this use._
+
 ## Starting a new project
 There are a couple of options of starting a new plugin project:
 * Use one of the [Applicaster examples](https://github.com/applicaster/zapp-plugins-examples/tree/master/VideoPlayer/iOS)

--- a/book/getting-started/ios-podspec.md
+++ b/book/getting-started/ios-podspec.md
@@ -21,8 +21,10 @@ There are 4 pod publishing strategies that a developer can use to create a versi
 3. Host the pod inside the plugin repository in a `Specs` folder
 4. Create a private podspec repository containing the podspecs
 
-Unfortunately, at the moment, a public pod isn't an option due to the fact that `ZappPlugins` dependency isn't published in Cocoapods public podspec repository.
+Unfortunately, at the moment, a public pod (on Cocoapods main repository) isn't an option due to the fact that `ZappPlugins` dependency isn't published in Cocoapods public podspec repository.
 While the code is opensourced - the nature of the needs to update versions derived by CI doesn't allow for a good workflow.
+
+_NOTE: When using private pods and pod repositories - it is mandatory to use SSH - `git@github.com/<account>/<dependancy>.git` in the `dependency_repository_url` field, and invite the CI github user to have access to the code. Unfortunatly HTTPS is not properly supported for this use._
 
 ### Create a public podspec repository
 The first option is simply creating an in-house public podspec repository.

--- a/book/zappifest/plugins-manifest-format.md
+++ b/book/zappifest/plugins-manifest-format.md
@@ -208,7 +208,7 @@ Field Key                         | Description
 **supports_offline**              | Boolean, valid option only for the screen plugins, indicates if this screen is supports offline mode in the app.
 **dependency_name**               | The name of the dependency as it defined in the repository
 **dependency_version**            | The version to be use for this dependency.
-**dependency_repository_url**     | A list of repo urls the plugin uses. _NOTE: for ANDROID use it as an object consists out of url and credentials. For any other platform provide a list of url's_
+**dependency_repository_url**     | A list of repo urls the plugin uses. _NOTE: for ANDROID use it as an object consists out of url and credentials. For any other platform provide a list of url's_, _NOTE: for iOS if the repository is private - please use ssh `git@github.com/<account>/<repository name>.git`_
 **extra_dependencies**            | iOS/tvOS only. An array of extra dependencies. Each element in the array is a map of the name of the dependencies and the relevant pod specs. See [example](#extra-dependencies)
 **project_dependencies**          | Android only. Project level counterpart dependencies of RN npm dependencies, Zappifest will ask to optionally add one for each npm dependency detected. See [example](#project-dependencies)
 **configuration_panel_disabled**  | set as true if the plugin configuration should not appear in the plugin gallery. It is recommended to do so when the plugin has a dedicated section in Zapp (Screens, Navigations, etc.)


### PR DESCRIPTION
## Description

Added clarifications in all relevant places that private repos on iOS must use SSH and not HTTPS

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [x] Documentation is included

* [ ] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
