### PR TITLE
specify video type

### DIFF
--- a/book/Zapp-Pipes/5.-Feed-API.md
+++ b/book/Zapp-Pipes/5.-Feed-API.md
@@ -183,7 +183,7 @@ The content element type attribute depends on the Entry type:
 - For Article use ```html```.
 - For Image use one of the following types:
 ```image/png```, ```image/gif```, ```image/jpg```, ```image/jpeg```
-- For Video use ```video/hls```.
+- For Video use ```video/hls``` for `HLS` type, ```video/dash``` for `DASH` type, ```video/mp4``` for `MP4` type, ```video/3gp``` for `3GP` type.
 - For YouTube Video use ```youtube-id```
 - For Image-gallery use ```application/atom+xml```
 - Article type MUST contain the escaped embedded HTML markup within. Any HTML tags that are not of the following ```<p>, <a>, <strong>,  <h2>, <h3>, <h4>, <h5>, <img>``` Aren't recommended and can cause bad article formatting.


### PR DESCRIPTION
## Description
We need to add specification to different video types than HLS. Android player need to implement separately Media Source for each type.

## Known issues

## Checklist

* [ ] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [ ] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :