### PR TITLE
fix(plugins-manifest-format): Add mention that whitelisted account ids update only on new plugin creation

### DIFF
--- a/book/zappifest/plugins-manifest-format.md
+++ b/book/zappifest/plugins-manifest-format.md
@@ -189,7 +189,7 @@ Field Key                   | Description
 **description**             | Describes the plugin.
 **type**                    | Plugin type out of predefined types.
 **min_zapp_sdk**            | minimum zapp version required for the field, when the plugin is a multi platform, please specify the the platform in the following format: `"min_zapp_sdk": { "ios": "1.0.0", "android": "1.0.0" }`
-**whitelisted_account_ids** | Optional. Array of Applicaster's account_ids as individual strings. To find the relevent account_ids go to `accounts.applicaster.com`. If empty, plugin will be available across all accounts.
+**whitelisted_account_ids** | Array of Applicaster's account_ids as individual strings. To find the relevent account_ids go to `accounts.applicaster.com`. Please note - this is only updated on new plugin creation. Any changed afterwards must be managed by admins in the Zapp portal.
 **ui_builder_support**      | Indicates if the plugin should be used in Zapp's UI Builder apps.
 **targets**      | Array type. Some platforms (like Android and Android TV) enables to develop the same plugin for mobile and TV. This param indicates if this plugin should be used on mobile or tv or both devise targets.  Currently the valid options is ["mobile"], ["tv"] or ["mobile", "tv"].
 

--- a/book/zappifest/plugins-manifest-format.md
+++ b/book/zappifest/plugins-manifest-format.md
@@ -189,7 +189,7 @@ Field Key                   | Description
 **description**             | Describes the plugin.
 **type**                    | Plugin type out of predefined types.
 **min_zapp_sdk**            | minimum zapp version required for the field, when the plugin is a multi platform, please specify the the platform in the following format: `"min_zapp_sdk": { "ios": "1.0.0", "android": "1.0.0" }`
-**whitelisted_account_ids** | Array of Applicaster's account_ids as individual strings. To find the relevent account_ids go to `accounts.applicaster.com`. Please note - this is only updated on new plugin creation. Any changed afterwards must be managed by admins in the Zapp portal.
+**whitelisted_account_ids** | Array of Applicaster's account_ids as individual strings. To find the relevent account_ids go to `accounts.applicaster.com`. *Please note - this is only updated on new plugin creation. Any changed afterwards must be managed by admins in the Zapp portal.*
 **ui_builder_support**      | Indicates if the plugin should be used in Zapp's UI Builder apps.
 **targets**      | Array type. Some platforms (like Android and Android TV) enables to develop the same plugin for mobile and TV. This param indicates if this plugin should be used on mobile or tv or both devise targets.  Currently the valid options is ["mobile"], ["tv"] or ["mobile", "tv"].
 

--- a/book/zappifest/plugins-manifest-format.md
+++ b/book/zappifest/plugins-manifest-format.md
@@ -189,7 +189,7 @@ Field Key                   | Description
 **description**             | Describes the plugin.
 **type**                    | Plugin type out of predefined types.
 **min_zapp_sdk**            | minimum zapp version required for the field, when the plugin is a multi platform, please specify the the platform in the following format: `"min_zapp_sdk": { "ios": "1.0.0", "android": "1.0.0" }`
-**whitelisted_account_ids** | Array of Applicaster's account_ids as individual strings. To find the relevent account_ids go to `accounts.applicaster.com`. *Please note - this is only updated on new plugin creation. Any changed afterwards must be managed by admins in the Zapp portal.*
+**whitelisted_account_ids** | Array of Applicaster's account_ids as individual strings. To find the relevent account_ids go to `accounts.applicaster.com`. *Please note - this field is only updated when creating a new plugin. Any further changes must be made by admins in the Zapp portal.*
 **ui_builder_support**      | Indicates if the plugin should be used in Zapp's UI Builder apps.
 **targets**      | Array type. Some platforms (like Android and Android TV) enables to develop the same plugin for mobile and TV. This param indicates if this plugin should be used on mobile or tv or both devise targets.  Currently the valid options is ["mobile"], ["tv"] or ["mobile", "tv"].
 


### PR DESCRIPTION
## Description

Following update on Zappifest 0.56 - add mention that whitelisted account ids are only updated on new plugin creation and that managing them can be done in the Zapp portal by admins

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [x] Documentation is included

* [ ] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :