### PR TITLE
fix(favicon): correct link to file

### DIFF
--- a/book.json
+++ b/book.json
@@ -11,7 +11,7 @@
   "pluginsConfig": {
     "theme-gestalt": {
       "logo": "/icons/applicaster.png",
-      "favicon": "/icons/favicon.png",
+      "favicon": "/icons/favicon.ico",
       "baseUrl": null,
       "excludeDefaultStyles": true,
       "doNotHideChildrenChapters": false


### PR DESCRIPTION
## Description
| before | after |
| --- | --- |
| <img width="89" alt="Screen Shot 2019-08-05 at 12 04 32 PM" src="https://user-images.githubusercontent.com/2690028/62452679-5b2b4900-b779-11e9-993f-c6bfdcc52595.png"> | <img width="78" alt="Screen Shot 2019-08-05 at 12 04 12 PM" src="https://user-images.githubusercontent.com/2690028/62452687-5e263980-b779-11e9-9455-806181ea4c09.png"> |

Bonuse feature! This fix also remove the annoying error in the console! Win-win!


## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [ ] This PR is not making any UI change
* [x] This PR is making a UI change
  * [x] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
