### PR TITLE
chores(npm): npm start & serve script

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run start
+web: npm run serve:production

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Updating existing document is a very easy task, just clone the repo, create a ne
 Adding a new document can be easily done by the following steps:
 
 1. Clone the repo.
-2. Run `$ npm install`.
+2. Run `npm install`.
 3. Create a new branch.
 4. Add the new `.md` file under the relevant folder.
 5. Add the file to the right place in the `/book/SUMMARY.md` according to the [Pages and Summary](https://toolchain.gitbook.com/pages.html) guide.
-6. Test your code locally by running the gitbook with `./debug_locally.sh` and checking the result in `http://localhost:4000/`.
+6. Test your code locally by running the gitbook with `npm start` and checking the result in `http://localhost:4000/`.
 7. Push the code.
 8. Create the pull request.
 

--- a/debug_locally.sh
+++ b/debug_locally.sh
@@ -1,2 +1,0 @@
-#!/bin/bash +x
-node ./node_modules/gitbook-cli/bin/gitbook.js serve

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   },
   "scripts": {
     "build": "node ./node_modules/gitbook-cli/bin/gitbook.js build",
-    "start": "node app.js",
-    "heroku-postbuild": "echo 'Building again to include SUMMARY.md' && npm run build"
+    "heroku-postbuild": "echo 'Building again to include SUMMARY.md' && npm run build",
+    "serve:debug": "node ./node_modules/gitbook-cli/bin/gitbook.js serve",
+    "serve:production": "node app.js",
+    "start": "npm run serve:debug"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
- Use the ubiquitous `npm install` + `npm start` scheme when working locally with the gitbook
- Updated procfile
- Why? Common pattern that does not require peeking into the README
- Also, Heroku does not mind handling long and complex scripts names... but we poor devs do!

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [x] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
