### PR TITLE
New parameters for DSP bridge

### DIFF
--- a/book/Zapp-Pipes/3.-Native-bridge-API.md
+++ b/book/Zapp-Pipes/3.-Native-bridge-API.md
@@ -15,7 +15,7 @@ The `nativeBridge` object provides the following methods :
   * `apiSecretKey`: api private key
   * `languageLocale`: language locale configured in the device
   * `countryLocale`: country locale configured in the device
-  * `advertisingIdentifier`: this returns the *idfa* for iOS and *aaid* for Android
+  * `advertisingIdentifier`: this returns the *idfa* for iOS and *aaid* for Android (if advertising is disabled this field is empty)
   * `deviceType`: *phone* or *tablet*
   * `deviceWidth`: width of the device
   * `deviceHeight`: height of the device

--- a/book/Zapp-Pipes/3.-Native-bridge-API.md
+++ b/book/Zapp-Pipes/3.-Native-bridge-API.md
@@ -11,10 +11,14 @@ The `nativeBridge` object provides the following methods :
   * `accountId`: Zapp account Id
   * `broadcasterId`: Applicaster broadcaster Id
   * `bundleIdentifier`: bundle identifier of the app
-  * `platform`: android or ios
+  * `platform`: *android* or *ios*
   * `apiSecretKey`: api private key
   * `languageLocale`: language locale configured in the device
   * `countryLocale`: country locale configured in the device
+  * `advertisingIdentifier`: this returns the *idfa* for iOS and *aaid* for Android
+  * `deviceType`: *phone* or *tablet*
+  * `deviceWidth`: width of the device
+  * `deviceHeight`: height of the device
   * `ver`: version number of the app (just Android)
   * `os_type`: operative system of the app. The value is always android (just Android)
   * `pluginConfigurations`: object with the plugin configurations (just Android)


### PR DESCRIPTION
## Description
I have added 4 new parameters (deviceType, deviceWidth, deviceHeight and advertisingIdentifier) in the native bridge for the DSP. This is the documentation for them.

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [x] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
