### PR TITLE
feat(ui_frameworks): add ui_frameworks field description

### DIFF
--- a/book/zappifest/plugins-manifest-format.md
+++ b/book/zappifest/plugins-manifest-format.md
@@ -191,7 +191,7 @@ Field Key                   | Description
 **min_zapp_sdk**            | minimum zapp version required for the field, when the plugin is a multi platform, please specify the the platform in the following format: `"min_zapp_sdk": { "ios": "1.0.0", "android": "1.0.0" }`
 **whitelisted_account_ids** | Array of Applicaster's account_ids as individual strings. To find the relevent account_ids go to `accounts.applicaster.com`. *Please note - this field is only updated when creating a new plugin. Any further changes must be made by admins in the Zapp portal.*
 **ui_builder_support**      | Indicates if the plugin should be used in Zapp's UI Builder apps.
-**targets**      | Array type. Some platforms (like Android and Android TV) enables to develop the same plugin for mobile and TV. This param indicates if this plugin should be used on mobile or tv or both devise targets.  Currently the valid options is ["mobile"], ["tv"] or ["mobile", "tv"].
+**targets**      | Array type. Some platforms (like Android and Android TV) enables to develop the same plugin for mobile and TV. This param indicates if this plugin should be used on mobile or tv or both device targets.  Currently the valid options is ["mobile"], ["tv"] or ["mobile", "tv"].
 
 
 #### Optional:
@@ -234,8 +234,9 @@ Field Key                         | Description
 **advertising**                   | An optional section the defines plugin data source configuration. Read more [here](#custom-configuration-sections).
 **preload**                   | An optional boolean key, that defines if plugin can be hooked (loaded), before the screen loads
 **localizations**						  | This section defines plugin localizations configuration, the languages is taken from app family configured languages. All the fields types in this section are `textarea`, and there is no need to mention field type in the manifest.  Read more [here](#custom-configuration-sections)
+**ui_frameworks**						  | Array type. Used to specify which UI Platforms are supported by the plugin. Available options: `["native", "quickbrick"]`. Default value: `["native"]`. Used to filter & show available plugins per app version in the Plugin Gallery.
 
-<a name=localizations"></a>
+
 ##### Localizations Example
 
 ```
@@ -394,9 +395,11 @@ Here is the example:
   },
 ```
 
-- ** screen_selector**
- -- This selector will allow the user to select a screen in the current layout, and return its `external_id`.
- Example : 
+- **screen_selector**
+-- This selector will allow the user to select a screen in the current layout, and return its `external_id`.
+
+Example:
+
 ```
 "general": {
     "fields": [
@@ -405,7 +408,7 @@ Here is the example:
             "label": "Target Screen",
             "type": "screen_selector"
         }
-    ]  
+    ]
 }
 ```
 


### PR DESCRIPTION
## Description
- New optional field in manifest: `ui_frameworks`
- Basic description of the available values

## Known issues
- The "what it does" section of this field is a bit vague since there it does not affect anything YET in the CMS. When the behavior in the CMS will change, there will be a matching PR explaining the filtering by ui_frameworks

#### Notes
- Could not resist the cleanup of the rogue`<a name=localizations"></a>` in the middle 😬 
<img width="311" alt="Screen Shot 2020-02-02 at 3 46 05 PM" src="https://user-images.githubusercontent.com/2690028/73609117-276b9780-45d3-11ea-8f08-10ba12e05f01.png">

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [x] Documentation is included

* [ ] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
