### PR TITLE
fix(*): Create new component was moved, removing the links.

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -104,7 +104,6 @@
     - [Navigation Structure](/ui-builder/ios/NavigationStructure.md)
     - [Rivers](/ui-builder/ios/Rivers.md)
     - [Classes and Plists](/ui-builder/ios/Classes-and-Plists.md)
-    - [Create new component](/ui-builder/ios/Creation-New-Component.md)
     - [Testing locally](/ui-builder/ios/Testing-Locally.md)
   - [Android](/ui-builder/android/android.md)
     - [Family Interface](/ui-builder/android/family-interface/family-interface.md)

--- a/book/ui-builder/intro.md
+++ b/book/ui-builder/intro.md
@@ -13,7 +13,6 @@ Table of contents:
 	* [Navigation Structure](/ui-builder/ios/NavigationStructure.md)
 	* [Rivers](/ui-builder/ios/Rivers.md)
 	* [Classes and Plists](/ui-builder/ios/Classes-and-Plists.md)
-	* [Create new component](/ui-builder/ios/Creation-New-Component.md)
 	* [Testing locally](/ui-builder/ios/Testing-Locally.md)
 * [Android UI Builder](/ui-builder/android/android.md)
 * [Url Scheme](/ui-builder/scheme/scheme.md)


### PR DESCRIPTION
## Description

Removing links to iOS/Create New Component from UI Builder as it was moved to a different location.

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
