### PR TITLE
fix(whats-new): adding plugin account guide to the menu and whats new main

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Download a development project](/getting-started/download-development-project.md)
   - [Public Plugin Submission Guideline](/plugins-guidelines/plugin_submission_guideline.md)
 - [What's New](whats_new/whats_new.md)
+  - [Plugins developer account](20200119_plugiun_accounts.md)
   - [DSP Protocols](whats_new/20191229-dsp-protocols.md)
   - [Migrating your plugin to Swift 5.1 with Zapp-iOS SDK v13.0](whats_new/20191124-swift-5.1-migration.md)
   - [Update repository structure in Zapp-iOS SDK v13.0](whats_new/20191120-update-zapp-ios-repository-structure.md)

--- a/book/whats_new/whats_new.md
+++ b/book/whats_new/whats_new.md
@@ -1,5 +1,8 @@
 # What's New
 
+## February 20 - 2020
+* [Plugins developer account and premissions](20200119_plugiun_accounts.md)
+
 ## December 29 - 2019
 * [Datasource Provider Protocols](20191229-dsp-protocols.md)
 


### PR DESCRIPTION
## Description

Adding the new plugins account guide to the site side menu and to the main screen of what's new.

## Known issues

## Checklist

* [ ] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [ ] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
