### PR TITLE
removing contact us page from the portal

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -31,7 +31,6 @@
   - [Update repository structure in Zapp-iOS SDK v13.0](whats_new/20191120-update-zapp-ios-repository-structure.md)
   - [Get ready for Zapp Android SDK 11.2.0](whats_new/20191112-get-ready-for-zapp-android-11.2.0.md)
   - [Migrating your plugin to Swift 5.0 with Zapp-iOS SDK v12.0](whats_new/20190818-swift-5.0-migration.md)
-- [Contact Us & Help Desk](/contact_us/help_desk.md)
 
 # Zapp Plugins
 


### PR DESCRIPTION
## Description

Removing the help desk page from the site as the "dev-rel service desk" is not available anymore.