### PR TITLE
chore(extensions) - Update push notification docs - Add notification extensions

### DIFF
--- a/book/push/push-ios.md
+++ b/book/push/push-ios.md
@@ -169,15 +169,15 @@ In the following example we added three parameters to the plist:
 To be able to add your custom implementation for the notification extension target on the project (one or more extensions)
 1. Create following folders structure in your repo
 ```bash
-    Extensions  
-            service 
-                    NotificationService.swift
-            content 
-                    NotificationViewController.swift
-
-    Scripts 
-            prepare_service_extension.sh
-            prepare_content_extension.sh
+    |-- Extensions  
+    |   |-- service 
+    |       |-- NotificationService.swift
+    |   |-- content 
+    |       |-- NotificationViewController.swift
+    |
+    |-- Scripts 
+    |   |-- prepare_service_extension.sh
+    |   |-- prepare_content_extension.sh
 ```
 Extensions folder will have the implementation for the notification extension main class that will replace default implementation exists on our project.
 2. Add `prepare_service_extension.sh` script with following code for the service extension

--- a/book/push/push-ios.md
+++ b/book/push/push-ios.md
@@ -166,6 +166,8 @@ In the following example we added three parameters to the plist:
 
 ## Podspec (iOS for QB SDK only) {#podspec} 
 
+* Min iOS for QB SDK version: 0.1.0
+
 To be able to add your custom implementation for the notification extension target on the project (one or more extensions)
 1. Create following folders structure in your repo (for one or both extension types)
 ```bash

--- a/book/push/push-ios.md
+++ b/book/push/push-ios.md
@@ -167,7 +167,7 @@ In the following example we added three parameters to the plist:
 ## Podspec (iOS for QB SDK only) {#podspec} 
 
 To be able to add your custom implementation for the notification extension target on the project (one or more extensions)
-1. Create following folders structure in your repo
+1. Create following folders structure in your repo (for one or both extension types)
 ```bash
     |-- Extensions  
     |   |-- service 

--- a/book/push/push-ios.md
+++ b/book/push/push-ios.md
@@ -164,18 +164,20 @@ In the following example we added three parameters to the plist:
 }
 ```
 
-## Podspec (iOS for QB SDK only) {#podspec}
+## Podspec (iOS for QB SDK only) {#podspec} 
 
 To be able to add your custom implementation for the notification extension target on the project (one or more extensions)
 1. Create following folders structure in your repo
 ```bash
-    Extensions  |__ service 
-                           |__ NotificationService.swift
-                |__ content 
-                           |__ NotificationViewController.swift
+    Extensions  
+            service 
+                    NotificationService.swift
+            content 
+                    NotificationViewController.swift
 
-    Scripts |__ prepare_service_extension.sh
-            |__ prepare_content_extension.sh
+    Scripts 
+            prepare_service_extension.sh
+            prepare_content_extension.sh
 ```
 Extensions folder will have the implementation for the notification extension main class that will replace default implementation exists on our project.
 2. Add `prepare_service_extension.sh` script with following code for the service extension

--- a/book/push/push-ios.md
+++ b/book/push/push-ios.md
@@ -164,7 +164,7 @@ In the following example we added three parameters to the plist:
 }
 ```
 
-## Podspec {#podspec}
+## Podspec (iOS for QB SDK only) {#podspec}
 
 To be able to add your custom implementation for the notification extension target on the project (one or more extensions)
 1. Create following folders structure in your repo

--- a/book/push/push-ios.md
+++ b/book/push/push-ios.md
@@ -141,7 +141,7 @@ The following steps will help you setup and add a Notification Service Extension
     ]
     ```
 
-    *__note__:* We are using the extension provisioning profile file on the Zapp app relesae proccess.  
+    *__note__:* We are using the extension provisioning profile file on the Zapp app release proccess.  
 
 ## Plist Addition {#plist}
 


### PR DESCRIPTION
## Description
Update push notification docs for **_QB iOS SDK only_** - Add explanations how to add different types of notification extensions to the project.


**working example in cocoapods pod update**: https://gist.github.com/alexzchut/dc49e89dc813dd5915c20f9a2080d50e#file-gistfile1-txt-L29
**circle build example using it**: https://app.circleci.com/pipelines/github/applicaster/ZappAppleBuilder/2804/workflows/59db3511-9bb2-4989-9efd-e37896e7e726/jobs/3041/parallel-runs/0/steps/0-121

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [x] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
